### PR TITLE
Made method abstract by accident

### DIFF
--- a/Milo/SlackIntegration/MiloMentionHandler.cs
+++ b/Milo/SlackIntegration/MiloMentionHandler.cs
@@ -9,12 +9,12 @@ namespace SlackIntegration;
 /// <summary>
 /// A message handler that responds to messages mentioning Milo.
 /// </summary>
-internal abstract class MiloMentionHandler(ISlackApiClient slack) : IEventHandler<MessageEvent>
+internal class MiloMentionHandler(ISlackApiClient slack) : IEventHandler<MessageEvent>
 {
     private const string MiloUserId = "<@U08GZTK3W5S>";
 
     public async Task Handle(MessageEvent slackEvent)
-    {   
+    {
         // Ignore messages from the bot itself
         if (slackEvent.User == MiloUserId )
         {


### PR DESCRIPTION
abstract classes cannot be added to event handlers, as they will not trigger. But apparantly it won't throw any form of error or warning either